### PR TITLE
fix i386 syscall argument constraints

### DIFF
--- a/sflib/darwin_i386/sfsyscall.h
+++ b/sflib/darwin_i386/sfsyscall.h
@@ -59,7 +59,7 @@ __asm__ volatile ("pushl %2\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $8, %%esp"  \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1))); \
+	: "0" (__NR_##name),"r" ((long)(arg1))); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -73,7 +73,7 @@ __asm__ volatile ("pushl %3\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $12, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)) ); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)) ); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -89,8 +89,8 @@ __asm__ volatile ("pusha; pushl %4\n\t"     \
 		  "add   $16, %%esp\n\t" \
 		  "popa" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)), \
-		  "g" ((long)(arg3)) ); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)), \
+		  "r" ((long)(arg3)) ); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -106,7 +106,7 @@ __asm__ volatile ("pushl %5\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $20, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)), \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)), \
 	  "d" ((long)(arg3)),"S" ((long)(arg4)) ); \
 __sfsyscall_return(type,__res); \
 } 
@@ -125,8 +125,8 @@ __asm__ volatile ("pushl %6\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $24, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)), \
-	  "g" ((long)(arg3)),"g" ((long)(arg4)),"g" ((long)(arg5))); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)), \
+	  "r" ((long)(arg3)),"r" ((long)(arg4)),"r" ((long)(arg5))); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -145,9 +145,9 @@ __asm__ volatile ("pushl %7\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $28, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)), \
-	  "g" ((long)(arg3)),"g" ((long)(arg4)),"g" ((long)(arg5)), \
-	  "g" ((long)(arg6))); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)), \
+	  "r" ((long)(arg3)),"r" ((long)(arg4)),"r" ((long)(arg5)), \
+	  "r" ((long)(arg6))); \
 __sfsyscall_return(type,__res); \
 }
 

--- a/sflib/freebsd_i386/syscall.h
+++ b/sflib/freebsd_i386/syscall.h
@@ -43,7 +43,7 @@ __asm__ volatile ("pushl %2\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $8, %%esp"  \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1))); \
+	: "0" (__NR_##name),"r" ((long)(arg1))); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -57,7 +57,7 @@ __asm__ volatile ("pushl %3\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $12, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)) ); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)) ); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -72,8 +72,8 @@ __asm__ volatile ("pushl %4\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $16, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)), \
-		  "g" ((long)(arg3)) ); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)), \
+		  "r" ((long)(arg3)) ); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -89,7 +89,7 @@ __asm__ volatile ("pushl %5\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $20, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)), \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)), \
 	  "d" ((long)(arg3)),"S" ((long)(arg4)) ); \
 __sfsyscall_return(type,__res); \
 } 
@@ -108,8 +108,8 @@ __asm__ volatile ("pushl %6\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $24, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)), \
-	  "g" ((long)(arg3)),"g" ((long)(arg4)),"g" ((long)(arg5))); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)), \
+	  "r" ((long)(arg3)),"r" ((long)(arg4)),"r" ((long)(arg5))); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -128,9 +128,9 @@ __asm__ volatile ("pushl %7\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $28, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)), \
-	  "g" ((long)(arg3)),"g" ((long)(arg4)),"g" ((long)(arg5)), \
-	  "g" ((long)(arg6))); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)), \
+	  "r" ((long)(arg3)),"r" ((long)(arg4)),"r" ((long)(arg5)), \
+	  "r" ((long)(arg6))); \
 __sfsyscall_return(type,__res); \
 }
 

--- a/sflib/linux_i386/syscall.h
+++ b/sflib/linux_i386/syscall.h
@@ -47,7 +47,7 @@ __asm__ volatile ("###> " #name "(%2) <###\n\t"    \
 		  "int $0x80\n\t"       \
                   "popl %%ebx"          \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1))); \
+	: "0" (__NR_##name),"r" ((long)(arg1))); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -61,7 +61,7 @@ __asm__ volatile ("###> " #name "(%2, %3) <###\n\t"    \
 		  "int $0x80\n\t"       \
                   "popl %%ebx"          \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)) ); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)) ); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -75,7 +75,7 @@ __asm__ volatile ("###> " #name "(%2, %3, %4) <###\n\t"    \
 		  "int $0x80\n\t"       \
                   "popl %%ebx"          \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)), \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)), \
 		  "d" ((long)(arg3)) ); \
 __sfsyscall_return(type,__res); \
 }
@@ -90,7 +90,7 @@ __asm__ volatile ("###> " #name "(%2, %3, %4, %5) <###\n\t"    \
 		  "int $0x80\n\t"       \
                   "popl %%ebx"          \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)), \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)), \
 	  "d" ((long)(arg3)),"S" ((long)(arg4)) ); \
 __sfsyscall_return(type,__res); \
 } 
@@ -106,7 +106,7 @@ __asm__ volatile ("###> " #name "(%2, %3, %4, %5, %6) <###\n\t"    \
 		  "int $0x80\n\t"       \
                   "popl %%ebx"          \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)), \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)), \
 	  "d" ((long)(arg3)),"S" ((long)(arg4)),"D" ((long)(arg5))); \
 __sfsyscall_return(type,__res); \
 }
@@ -125,9 +125,9 @@ __asm__ volatile ("##> " #name "(%2, %3, %4, %5, %6, %7) <###\n\t"    \
 		  "popl %%ebp\n\t"   \
                   "popl %%ebx"       \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)), \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)), \
 	  "d" ((long)(arg3)),"S" ((long)(arg4)),"D" ((long)(arg5)), \
-	  "g" ((long)(arg6))); \
+	  "r" ((long)(arg6))); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -149,9 +149,9 @@ __asm__ volatile ("pushl %%ebx\n\t"  \
                   "add $0x18,%%esp\n\t"  \
                   "popl %%ebx"   \
         : "=a" (__res) \
-        : "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)), \
-          "g" ((long)(arg3)),"g" ((long)(arg4)),"g" ((long)(arg5)), \
-          "g" ((long)(arg6))); \
+        : "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)), \
+          "r" ((long)(arg3)),"r" ((long)(arg4)),"r" ((long)(arg5)), \
+          "r" ((long)(arg6))); \
 __sfsyscall_return(type,__res); \
 }
 

--- a/sflib/openbsd_i386/syscall.h
+++ b/sflib/openbsd_i386/syscall.h
@@ -34,7 +34,7 @@ __asm__ volatile ("pushl %2\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $8, %%esp"  \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1))); \
+	: "0" (__NR_##name),"r" ((long)(arg1))); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -48,7 +48,7 @@ __asm__ volatile ("pushl %3\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $12, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)) ); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)) ); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -63,8 +63,8 @@ __asm__ volatile ("pushl %4\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $16, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)), \
-		  "g" ((long)(arg3)) ); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)), \
+		  "r" ((long)(arg3)) ); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -80,7 +80,7 @@ __asm__ volatile ("pushl %5\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $20, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"c" ((long)(arg2)), \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"c" ((long)(arg2)), \
 	  "d" ((long)(arg3)),"S" ((long)(arg4)) ); \
 __sfsyscall_return(type,__res); \
 } 
@@ -99,8 +99,8 @@ __asm__ volatile ("pushl %6\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $24, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)), \
-	  "g" ((long)(arg3)),"g" ((long)(arg4)),"g" ((long)(arg5))); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)), \
+	  "r" ((long)(arg3)),"r" ((long)(arg4)),"r" ((long)(arg5))); \
 __sfsyscall_return(type,__res); \
 }
 
@@ -119,9 +119,9 @@ __asm__ volatile ("pushl %7\n\t"     \
 		  "int   $0x80\n\t"  \
 		  "add   $28, %%esp" \
 	: "=a" (__res) \
-	: "0" (__NR_##name),"g" ((long)(arg1)),"g" ((long)(arg2)), \
-	  "g" ((long)(arg3)),"g" ((long)(arg4)),"g" ((long)(arg5)), \
-	  "g" ((long)(arg6))); \
+	: "0" (__NR_##name),"r" ((long)(arg1)),"r" ((long)(arg2)), \
+	  "r" ((long)(arg3)),"r" ((long)(arg4)),"r" ((long)(arg5)), \
+	  "r" ((long)(arg6))); \
 __sfsyscall_return(type,__res); \
 }
 


### PR DESCRIPTION
at some point in the past it seems like the argument constraint went from "r"  (rgeneral register) to "g" (anything but non-general registers) since all syscall callers are changing the stack pointer by pushing ebx on the stack without the compiler's knowledge, this causes bugs when the compiler chooses to save the argument on the stack, as it cannot reference it correctly later.

switch back to "r" constraint to resolve this issue.